### PR TITLE
Rename chef_user and chef_org

### DIFF
--- a/resources/chef_server_org.rb
+++ b/resources/chef_server_org.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 # rubocop:disable LineLength
 
-resource_name 'chef_org'
+resource_name 'chef_server_org'
 default_action :create
 
 property :org, String, name_property: true

--- a/resources/chef_server_user.rb
+++ b/resources/chef_server_user.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: chef_stack
-# Resource:: chef_user
+# Resource:: chef_server_user
 #
 # Copyright 2016 Chef Software Inc
 #
@@ -17,7 +17,7 @@
 # limitations under the License.
 # rubocop:disable LineLength
 
-resource_name 'chef_user'
+resource_name 'chef_server_user'
 default_action :create
 
 property :username, String, name_property: true


### PR DESCRIPTION
These resource names are currently used by the Cheffish project for interacting with
the chef server api. These resources don't perform exactly the same functionality, so having
the resources from this cookbook makes sense, with different resource names.